### PR TITLE
Update tray items

### DIFF
--- a/main/tray.js
+++ b/main/tray.js
@@ -23,9 +23,14 @@ module.exports = function (/** @type {import('./typings').Context} */ ctx) {
   tray = new Tray(icon(on))
   const contextMenu = Menu.buildFromTemplate([
     {
-      label: `Filecoin Station v${STATION_VERSION}`,
+      label: 'Open Station',
+      click: () => ctx.showUI()
+    },
+    {
+      label: 'Learn more…',
       click: () => { shell.openExternal(`https://github.com/filecoin-project/filecoin-station/releases/v${STATION_VERSION}`) }
     },
+    { type: 'separator' },
     {
       id: 'checkForUpdates',
       label: 'Check for Updates...',
@@ -44,11 +49,6 @@ module.exports = function (/** @type {import('./typings').Context} */ ctx) {
       }
     },
     { type: 'separator' },
-    {
-      id: 'showUi',
-      label: 'Show UI',
-      click: () => ctx.showUI()
-    },
     {
       label: 'Start at login',
       type: 'checkbox',


### PR DESCRIPTION
- The main CTA was `Filecoin Station ${version}`, which opens a browser instead of Station. Therefore I made the first item the one to open station
- I renamed the item from `Show UI` (too technical) to `Open Station`
- The preview item `Filecoin Station ${version}` is now `Learn more...`
- I gave `Start at login` its own group, since it's the only one of its kind

Now:

<img width="333" alt="Screenshot 2022-09-29 at 18 03 35" src="https://user-images.githubusercontent.com/10247/193081692-61959c82-bfe3-47c8-8fff-71aebf58004a.png">

Previously:

<img width="343" alt="Screenshot 2022-09-29 at 18 03 50" src="https://user-images.githubusercontent.com/10247/193081727-ed71a760-7fe6-4f04-b743-163b79ab8c59.png">
