### PR TITLE
Reduce saturn stats poll frequency for perf. Closes #198

### DIFF
--- a/main/saturn-node.js
+++ b/main/saturn-node.js
@@ -137,7 +137,7 @@ async function start (/** @type {Context} */ ctx) {
         pollStatsInterval = setInterval(() => {
           pollStats(ctx)
             .catch(err => console.warn('Cannot fetch Saturn module stats.', err))
-        }, 100)
+        }, 1000)
         resolve()
       }
     }


### PR DESCRIPTION
Closes #198

One could even argue that a 1s interval is better for the user, because it makes the UI less hectic