### PR TITLE
Fix dashboard high cpu usage

### DIFF
--- a/renderer/src/pages/Dashboard.tsx
+++ b/renderer/src/pages/Dashboard.tsx
@@ -36,7 +36,7 @@ const Dashboard = (): JSX.Element => {
     setTotalJobs(await getTotalJobsCompleted())
   }
 
-  useEffect(() => { reload() })
+  useEffect(() => { reload() }, [])
 
   useEffect(() => {
     const unsubscribeOnActivityLogged = window.electron.stationEvents.onActivityLogged(setActivities)


### PR DESCRIPTION
Without a dependencies array, the effect was executed on every component call, instead of once initially.