### PR TITLE
build: cancel CI builds after a PR was updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
     tags:
       - '*'
 
+# This cancels in-progress jobs or runs on pull_request events only
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
   ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder


### PR DESCRIPTION
Configure GitHub Actions Workflow to cancel any pending or in-progress runs of our CI build after the pull request being tested has been modified. We are interested in the result of the new build that will be started for the updated version.

Preserve the old behavior for the `main` branch, where we want to build every commit even when new commits were added before the CI finished.
