### PR TITLE
test: use temp dir for config & cache

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -80,5 +80,5 @@ Set `DEBUG=pw:browser` to obtain console logs from the electron app under test.
 
 ```shell
 $ npm run build
-$ DEBUG=pw:browser npm run test:e2
+$ DEBUG=pw:browser npm run test:e2e
 ```

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -73,3 +73,12 @@ support.
 
 After updating to a newer Chromium version, update the compilation target for
 `renderer` files in [vite.config.js](./../vite.config.js).
+
+## Troubleshooting end-to-end tests
+
+Set `DEBUG=pw:browser` to obtain console logs from the electron app under test.
+
+```shell
+$ npm run build
+$ DEBUG=pw:browser npm run test:e2
+```

--- a/main/consts.js
+++ b/main/consts.js
@@ -21,8 +21,8 @@ module.exports = Object.freeze({
 // Replace with `app.get('localUserData')` after this PR is landed & released:
 // https://github.com/electron/electron/pull/34337
 function getCacheHome () {
-  if (process.env.NODE_ENV === 'test' && process.env.HOME) {
-    return path.join(process.env.HOME, 'local-user-data')
+  if (process.env.STATION_ROOT) {
+    return path.join(process.env.STATION_ROOT, 'cache')
   }
 
   const platform = os.platform()

--- a/main/consts.js
+++ b/main/consts.js
@@ -21,6 +21,10 @@ module.exports = Object.freeze({
 // Replace with `app.get('localUserData')` after this PR is landed & released:
 // https://github.com/electron/electron/pull/34337
 function getCacheHome () {
+  if (process.env.NODE_ENV === 'test' && process.env.HOME) {
+    return path.join(process.env.HOME, 'local-user-data')
+  }
+
   const platform = os.platform()
   switch (platform) {
     case 'darwin': // macOS

--- a/main/index.js
+++ b/main/index.js
@@ -11,7 +11,7 @@ const path = require('node:path')
 if (process.env.STATION_ROOT) {
   app.setPath('userData', path.join(process.env.STATION_ROOT, 'user-data'))
 
-  // Set also 'localUserData' after this PR is landed & released:
+  // Also set 'localUserData' after this PR is landed & released:
   // We are using localUserData for Saturn L2 cache
   // https://github.com/electron/electron/pull/34337
 }

--- a/main/index.js
+++ b/main/index.js
@@ -4,9 +4,6 @@ const { app, dialog } = require('electron')
 const log = require('electron-log')
 const path = require('node:path')
 
-const inTest = (process.env.NODE_ENV === 'test')
-const isDev = !app.isPackaged && !inTest
-
 // Override the place where we look for config files when running the end-to-end test suite.
 // We must call this early on, before any of our modules accesses the config store.
 // https://www.npmjs.com/package/electron-store
@@ -37,6 +34,9 @@ const { setup: setupDialogs } = require('./dialog')
 
 /** @typedef {import('./typings').Activity} Activity */
 /** @typedef {import('./typings').RecordActivityArgs} RecordActivityOptions */
+
+const inTest = (process.env.NODE_ENV === 'test')
+const isDev = !app.isPackaged && !inTest
 
 console.log('Filecoin Station build version:', BUILD_VERSION)
 

--- a/main/index.js
+++ b/main/index.js
@@ -11,8 +11,8 @@ const isDev = !app.isPackaged && !inTest
 // We must call this early on, before any of our modules accesses the config store.
 // https://www.npmjs.com/package/electron-store
 // https://www.electronjs.org/docs/latest/api/app#appgetpathname
-if (inTest && process.env.HOME) {
-  app.setPath('userData', path.join(process.env.HOME, 'user-data'))
+if (process.env.STATION_ROOT) {
+  app.setPath('userData', path.join(process.env.STATION_ROOT, 'user-data'))
 
   // Set also 'localUserData' after this PR is landed & released:
   // We are using localUserData for Saturn L2 cache

--- a/main/station-config.js
+++ b/main/station-config.js
@@ -3,6 +3,8 @@
 const Store = require('electron-store')
 const configStore = new Store()
 
+console.log('Loading Station configuration from', configStore.path)
+
 const ConfigKeys = {
   OnboardingCompleted: 'station.onboardingCompleted',
   TrayOperationExplained: 'station.TrayOperationExplained'

--- a/test/e2e/app-launch.e2e.test.js
+++ b/test/e2e/app-launch.e2e.test.js
@@ -24,13 +24,13 @@ test.describe.serial('Application launch', async () => {
     test.slow()
 
     // Launch Electron app against sandbox fake HOME dir
-    const userData = tmp.dirSync({ prefix: 'tmp_home_', unsafeCleanup: true }).name
+    const stationRootDir = tmp.dirSync({ prefix: 'station-', unsafeCleanup: true }).name
     electronApp = await electron.launch({
       args: [path.join(__dirname, '..', '..', 'main', 'index.js')],
       env: {
         ...process.env,
         NODE_ENV: 'test',
-        HOME: userData
+        STATION_ROOT: stationRootDir
       },
       timeout: 30000 * TIMEOUT_MULTIPLIER
     })

--- a/test/e2e/app-launch.e2e.test.js
+++ b/test/e2e/app-launch.e2e.test.js
@@ -82,7 +82,7 @@ test.describe.serial('Application launch', async () => {
 
       // Return the last observed value. It may be undefined if the promise above has not finished yet
       return (/** @type {any} */(window)).__saturnNodeIsReady
-    }, [], { timeout: 1000 * TIMEOUT_MULTIPLIER })
+    }, [], { timeout: 2000 * TIMEOUT_MULTIPLIER })
   })
 
   test('saturn WebUI is available', async () => {


### PR DESCRIPTION
Fix the way we are determining the location of our config files and module caches when running end-to-end tests.

Before this change, E2E tests on macOS would load the configuration from user's home directory. This config typically already has the FIL wallet address configured, thus the app skips the onboarding flow, and the test suite fails.

After this change, when running the tests, the app always uses the temporary directory provided via `process.env.HOME`
