### PR TITLE
Fix show UI when opening Station twice. Closes #266

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -111,6 +111,10 @@ app.on('before-quit', () => {
   Sentry.close()
 })
 
+app.on('second-instance', () => {
+  ctx.showUI()
+})
+
 process.on('uncaughtException', err => {
   Sentry.captureException(err)
   log.error(err)

--- a/main/index.js
+++ b/main/index.js
@@ -72,6 +72,10 @@ if (!app.requestSingleInstanceLock() && !inTest) {
   app.quit()
 }
 
+app.on('second-instance', () => {
+  ctx.showUI()
+})
+
 const jobStats = new JobStats()
 
 const activityLog = new ActivityLog()
@@ -109,10 +113,6 @@ app.on('before-quit', () => {
   // Flush pending events immediately
   // See https://docs.sentry.io/platforms/node/configuration/draining/
   Sentry.close()
-})
-
-app.on('second-instance', () => {
-  ctx.showUI()
 })
 
 process.on('uncaughtException', err => {

--- a/main/index.js
+++ b/main/index.js
@@ -68,7 +68,7 @@ if (process.platform === 'win32') {
 }
 
 // Only one instance can run at a time
-if (!app.requestSingleInstanceLock() && !inTest) {
+if (!inTest && !app.requestSingleInstanceLock()) {
   app.quit()
 }
 

--- a/main/index.js
+++ b/main/index.js
@@ -72,6 +72,8 @@ if (!inTest && !app.requestSingleInstanceLock()) {
   app.quit()
 }
 
+// When the user attempts to start the app and didn't notice the Station icon in
+// the tray, help them out by showing the main window
 app.on('second-instance', () => {
   ctx.showUI()
 })


### PR DESCRIPTION
In #266, @walkerlj0 thought Station didn't open when she opened it, although it was already open (and hidden in the tray).

This change makes it so the app show its UI when you open it a second time, to try to recover from that situation.

Closes #266.