### PR TITLE
fix: always report errors to Sentry

### DIFF
--- a/main/setup-sentry.js
+++ b/main/setup-sentry.js
@@ -3,8 +3,12 @@
 const Sentry = require('@sentry/node')
 const { BUILD_VERSION } = require('./consts')
 
+// const isDevBuild = BUILD_VERSION.endsWith('-dev')
+// ^^ Temporarily disabled, see https://github.com/filecoin-station/filecoin-station/issues/263
+const isDevBuild = false
+
 // Disable Sentry integration for dev builds
-if (!BUILD_VERSION.endsWith('-dev')) {
+if (isDevBuild) {
   // Importing @sentry/tracing patches the global hub for tracing to work.
   require('@sentry/tracing')
 

--- a/renderer/src/components/Sentry.tsx
+++ b/renderer/src/components/Sentry.tsx
@@ -5,7 +5,8 @@ import { BrowserTracing } from '@sentry/tracing'
 const SentryComponent = () => {
   useEffect(() => {
     // Disable Sentry integration for dev builds
-    if (window.electron.stationBuildVersion.endsWith('-dev')) { return }
+    // if (window.electron.stationBuildVersion.endsWith('-dev')) { return }
+    // ^^ Temporarily disabled, see https://github.com/filecoin-station/filecoin-station/issues/263
 
     Sentry.init({
       dsn: 'https://ff9615d8516545158e186d863a06a0f1@o1408530.ingest.sentry.io/6762462',


### PR DESCRIPTION
As a short-term fix for the broken detection of dev vs production builds (see #263), let's enable Sentry error reporting for all builds.

IMO, it's better to have some noise in our bug reports than have no errors captured at all.

