### PR TITLE
fix: always build for x64 on macOS

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -30,6 +30,10 @@ mac:
   gatekeeperAssess: false
   entitlements: 'build/entitlements.mac.plist'
   entitlementsInherit: 'build/entitlements.mac.plist'
+  target:
+    - target: dmg
+      arch: ['x64']
+
 
 dmg:
   iconSize: 160


### PR DESCRIPTION
Before this change, when running `npm run package` on an Apple M1/M2 computer, electron builder was creating a package for `arm64`. Since we are not downloading Saturn L2 node for `arm64`, we ended up with a broken Station app.

In this commit, I am changing electron-builder config to always build for `x64` when running on macOS.
