### PR TITLE
refactor: move station activity jobs rpc into hook

### DIFF
--- a/renderer/src/hooks/StationActivity.tsx
+++ b/renderer/src/hooks/StationActivity.tsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react'
+import { getTotalJobsCompleted, getAllActivities, getTotalEarnings } from '../lib/station-config'
+import { ActivityEventMessage } from '../typings'
+
+interface StationActivity {
+  totalJobs: number,
+  totalEarnings: number,
+  activities: ActivityEventMessage[] | []
+}
+const useStationActivity = (): StationActivity => {
+  const [totalJobs, setTotalJobs] = useState<number>(0)
+  const [activities, setActivities] = useState<ActivityEventMessage[]>([])
+  const [totalEarnings, setTotalEarnigs] = useState<number>(0)
+
+  useEffect(() => {
+    const loadStoredInfo = async () => setTotalJobs(await getTotalJobsCompleted())
+    loadStoredInfo()
+  }, [])
+
+  useEffect(() => {
+    const loadStoredInfo = async () => setActivities(await getAllActivities())
+    loadStoredInfo()
+  }, [])
+
+  useEffect(() => {
+    const loadStoredInfo = async () => setTotalEarnigs(await getTotalEarnings())
+    loadStoredInfo()
+  }, [])
+
+  useEffect(() => {
+    const unsubscribeOnJobProcessed = window.electron.stationEvents.onJobProcessed(setTotalJobs)
+    return () => {
+      unsubscribeOnJobProcessed()
+    }
+  }, [])
+
+  useEffect(() => {
+    const unsubscribeOnActivityLogged = window.electron.stationEvents.onActivityLogged(setActivities)
+    return () => {
+      unsubscribeOnActivityLogged()
+    }
+  }, [])
+
+  useEffect(() => {
+    const unsubscribeOnEarningsChanged = window.electron.stationEvents.onEarningsChanged(setTotalEarnigs)
+    return () => {
+      unsubscribeOnEarningsChanged()
+    }
+  }, [])
+
+  return { totalJobs, totalEarnings, activities }
+}
+
+export default useStationActivity

--- a/renderer/src/pages/Dashboard.tsx
+++ b/renderer/src/pages/Dashboard.tsx
@@ -1,24 +1,17 @@
 import { useEffect, useState } from 'react'
-import {
-  getAllActivities, stopSaturnNode,
-  setFilAddress, getFilAddress,
-  getTotalEarnings, getTotalJobsCompleted
-} from '../lib/station-config'
-import { ActivityEventMessage } from '../typings'
+import { stopSaturnNode, setFilAddress, getFilAddress } from '../lib/station-config'
 import ActivityLog from '../components/ActivityLog'
 import HeaderBackgroundImage from '../assets/img/header.png'
 import WalletIcon from '../assets/img/wallet.svg'
 import { useNavigate } from 'react-router-dom'
 import { confirmChangeWalletAddress } from '../lib/dialogs'
 import UpdateBanner from '../components/UpdateBanner'
+import useStationActivity from '../hooks/StationActivity'
 
 const Dashboard = (): JSX.Element => {
   const navigate = useNavigate()
-
   const [address, setAddress] = useState<string | undefined>()
-  const [totalJobs, setTotalJobs] = useState<number>(0)
-  const [totalEarnings, setTotalEarnigs] = useState<number>(0)
-  const [activities, setActivities] = useState<ActivityEventMessage[]>([])
+  const { totalJobs, totalEarnings, activities } = useStationActivity()
   const shortAddress = (str: string) => str
     ? str.substring(0, 4) + '...' + str.substring(str.length - 4, str.length)
     : ''
@@ -32,24 +25,9 @@ const Dashboard = (): JSX.Element => {
 
   useEffect(() => {
     const loadStoredInfo = async () => {
-      Promise.all([
-        (async () => { setAddress(await getFilAddress()) })(),
-        (async () => { setActivities(await getAllActivities()) })(),
-        (async () => { setTotalEarnigs(await getTotalEarnings()) })(),
-        (async () => { setTotalJobs(await getTotalJobsCompleted()) })()
-      ])
+      setAddress(await getFilAddress())
     }
     loadStoredInfo()
-
-    const unsubscribeOnActivityLogged = window.electron.stationEvents.onActivityLogged(setActivities)
-    const unsubscribeOnEarningsChanged = window.electron.stationEvents.onEarningsChanged(setTotalEarnigs)
-    const unsubscribeOnJobProcessed = window.electron.stationEvents.onJobProcessed(setTotalJobs)
-
-    return () => {
-      unsubscribeOnActivityLogged()
-      unsubscribeOnEarningsChanged()
-      unsubscribeOnJobProcessed()
-    }
   }, [])
 
   return (


### PR DESCRIPTION
This PR moves activity-related API calls into a dedicated hook. Also splits RPC calls into multiple `useEffect` instead of anonymous functions being called inside `Promise.all`