### PR TITLE
feat: improve logging

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -1,8 +1,11 @@
 'use strict'
 
 const { app, dialog } = require('electron')
-const log = require('electron-log')
+const electronLog = require('electron-log')
 const path = require('node:path')
+
+console.log('Log file:', electronLog.transports.file.findLogPath())
+const log = electronLog.scope('main')
 
 // Override the place where we look for config files when running the end-to-end test suite.
 // We must call this early on, before any of our modules accesses the config store.
@@ -23,6 +26,7 @@ const { ActivityLog } = require('./activity-log')
 const { BUILD_VERSION } = require('./consts')
 const { JobStats } = require('./job-stats')
 const { ipcMain } = require('electron/main')
+const os = require('os')
 const saturnNode = require('./saturn-node')
 const serve = require('electron-serve')
 const { setupAppMenu } = require('./app-menu')
@@ -38,7 +42,8 @@ const { setup: setupDialogs } = require('./dialog')
 const inTest = (process.env.NODE_ENV === 'test')
 const isDev = !app.isPackaged && !inTest
 
-console.log('Filecoin Station build version:', BUILD_VERSION)
+log.info('Filecoin Station build version:', BUILD_VERSION, isDev ? '[DEV]' : '', inTest ? '[TEST]' : '')
+log.info('Running on %s %s version %s', os.platform(), os.arch(), os.release())
 
 // Expose additional metadata for Electron preload script
 process.env.STATION_BUILD_VERSION = BUILD_VERSION

--- a/main/station-config.js
+++ b/main/station-config.js
@@ -3,6 +3,8 @@
 const Store = require('electron-store')
 const { randomUUID } = require('crypto')
 
+const log = require('electron-log').scope('config')
+
 const ConfigKeys = {
   OnboardingCompleted: 'station.OnboardingCompleted',
   TrayOperationExplained: 'station.TrayOperationExplained',
@@ -30,7 +32,7 @@ const configStore = new Store({
   }
 })
 
-console.log('Loading Station configuration from', configStore.path)
+log.info('Loading Station configuration from', configStore.path)
 
 let OnboardingCompleted = /** @type {boolean} */ (configStore.get(ConfigKeys.OnboardingCompleted, false))
 let TrayOperationExplained = /** @type {boolean} */ (configStore.get(ConfigKeys.TrayOperationExplained, false))

--- a/main/updater.js
+++ b/main/updater.js
@@ -29,6 +29,7 @@ function beforeQuitCleanup () {
 }
 
 function setup (/** @type {import('./typings').Context} */ _ctx) {
+  autoUpdater.logger = log
   autoUpdater.autoDownload = false // we download manually in 'update-available'
 
   autoUpdater.on('error', onUpdaterError)


### PR DESCRIPTION
- feat: log auto-updater messages
- feat: log station-config messages to log file
- feat: log Station build version and computer info

Example stdout output:

```
Log file: /Users/bajtos/Library/Logs/Filecoin Station/main.log
11:48:33.975 (config) › Loading Station configuration from /Users/bajtos/Library/Application Support/Filecoin Station/config.json
11:48:34.004 (main)    › Filecoin Station build version: 0.11.3.1-dev [DEV]
11:48:34.004 (main)    › Running on darwin arm64 version 22.1.0
(node:17388) DeprecationWarning: findLogPath() is deprecated and will be removed in v5.
```

Notice the deprecation warning about `findLogPath()`. The documentation does not explain what we should use instead of `findLogPath()` 🙁

With my changes in place, we can improve our UI for reporting problems and allow users to send their electron-log file, too. Perhaps in addition to the Saturn log file. Or we can change the Saturn Module to log messages using electron-log, so that we have everything in one place. Either way, that's out of scope of my PR.