### PR TITLE
fix unactionable Sentry errors

### DIFF
--- a/main/telemetry.js
+++ b/main/telemetry.js
@@ -22,7 +22,9 @@ const writeClient = client.getWriteApi(
 
 setInterval(() => {
   writeClient.flush().catch(err => {
-    Sentry.captureException(err)
+    if (!/HttpError|getAddrInfo|RequestTimedOutError/i.test(String(err))) {
+      Sentry.captureException(err)
+    }
   })
 }, 5000).unref()
 

--- a/main/telemetry.js
+++ b/main/telemetry.js
@@ -22,9 +22,8 @@ const writeClient = client.getWriteApi(
 
 setInterval(() => {
   writeClient.flush().catch(err => {
-    if (!/HttpError|getAddrInfo|RequestTimedOutError/i.test(String(err))) {
-      Sentry.captureException(err)
-    }
+    if (/HttpError|getAddrInfo|RequestTimedOutError/i.test(String(err))) return;
+    Sentry.captureException(err)
   })
 }, 5000).unref()
 

--- a/main/telemetry.js
+++ b/main/telemetry.js
@@ -22,6 +22,7 @@ const writeClient = client.getWriteApi(
 
 setInterval(() => {
   writeClient.flush().catch(err => {
+    // Ignore unactionable InfluxDB errors
     if (/HttpError|getAddrInfo|RequestTimedOutError/i.test(String(err))) return;
     Sentry.captureException(err)
   })


### PR DESCRIPTION
It's not really actionable for us when Influx is slow or unreachable (can be either Influx or the client's connection)