### PR TITLE
Fix Electron building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,8 @@ jobs:
           APPLEID: ${{ secrets.apple_id }}
           APPLEIDPASS: ${{ secrets.apple_id_pass }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEBUG: electron-builder
+          NPM_CONFIG_LOGLEVEL: silly
 
       - name: Show dist/
         run: du -sh dist/ && ls -l dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,93 +13,93 @@ env:
 
 jobs:
 
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+  # build:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [macos-latest, ubuntu-latest, windows-latest]
 
-    steps:
-      - name: Fix CRLF handling on Windows
-        if: matrix.os == 'windows-latest'
-        run: git config --global core.autocrlf false
+  #   steps:
+  #     - name: Fix CRLF handling on Windows
+  #       if: matrix.os == 'windows-latest'
+  #       run: git config --global core.autocrlf false
 
-      - name: Check out Git repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  #     - name: Check out Git repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Install Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 'lts/*'
+  #     - name: Install Node.js
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 'lts/*'
 
-      - name: Cache bigger downloads
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: ${{ github.workspace }}/.cache
-          key: ${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json', 'electron-builder.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json', 'electron-builder.yml') }}
-            ${{ runner.os }}-
+  #     - name: Cache bigger downloads
+  #       uses: actions/cache@v2
+  #       id: cache
+  #       with:
+  #         path: ${{ github.workspace }}/.cache
+  #         key: ${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json', 'electron-builder.yml') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json', 'electron-builder.yml') }}
+  #           ${{ runner.os }}-
 
-      - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --progress=false --cache ${{ github.workspace }}/.cache/npm
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Install dependencies
+  #       run: npm ci --prefer-offline --no-audit --progress=false --cache ${{ github.workspace }}/.cache/npm
+  #       env:
+  #           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build
-        run: npm run build
+  #     - name: Build
+  #       run: npm run build
 
-      - name: Install Sentry CLI
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          curl -sL https://sentry.io/get-cli/ | bash
-          sentry-cli --version
+  #     - name: Install Sentry CLI
+  #       if: matrix.os == 'ubuntu-latest'
+  #       run: |
+  #         curl -sL https://sentry.io/get-cli/ | bash
+  #         sentry-cli --version
 
-      - name: Configure SENTRY env vars
-        run:
-          node ./build/configure-sentry.js >> $GITHUB_ENV
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  #     - name: Configure SENTRY env vars
+  #       run:
+  #         node ./build/configure-sentry.js >> $GITHUB_ENV
+  #       env:
+  #         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      - name: Create Sentry release
-        # Secrets are not passed to the runner when a workflow is triggered from a forked repository.
-        # See https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow
-        # We skip this step in such case.
-        #
-        # We must use `env` instead of `secrets`, see https://stackoverflow.com/a/70249520/69868
-        if: matrix.os == 'ubuntu-latest' && env.SENTRY_AUTH_TOKEN
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: protocol-labs-ip
-          SENTRY_PROJECT: filecoin-station
-        run: |
-          sentry-cli releases new "${{ env.SENTRY_VERSION }}"
-          sentry-cli releases set-commits "${{ env.SENTRY_VERSION }}" --local --ignore-missing
-          sentry-cli releases files "${{ env.SENTRY_VERSION }}" upload-sourcemaps ./renderer/dist/assets
-          sentry-cli releases deploys "${{ env.SENTRY_VERSION }}" new -e "${{ env.SENTRY_ENV }}"
+  #     - name: Create Sentry release
+  #       # Secrets are not passed to the runner when a workflow is triggered from a forked repository.
+  #       # See https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow
+  #       # We skip this step in such case.
+  #       #
+  #       # We must use `env` instead of `secrets`, see https://stackoverflow.com/a/70249520/69868
+  #       if: matrix.os == 'ubuntu-latest' && env.SENTRY_AUTH_TOKEN
+  #       env:
+  #         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  #         SENTRY_ORG: protocol-labs-ip
+  #         SENTRY_PROJECT: filecoin-station
+  #       run: |
+  #         sentry-cli releases new "${{ env.SENTRY_VERSION }}"
+  #         sentry-cli releases set-commits "${{ env.SENTRY_VERSION }}" --local --ignore-missing
+  #         sentry-cli releases files "${{ env.SENTRY_VERSION }}" upload-sourcemaps ./renderer/dist/assets
+  #         sentry-cli releases deploys "${{ env.SENTRY_VERSION }}" new -e "${{ env.SENTRY_ENV }}"
 
-      - name: Test backend
-        run: npm run test:backend
+  #     - name: Test backend
+  #       run: npm run test:backend
 
-      - name: Test frontend
-        run: npm run test:ui
+  #     - name: Test frontend
+  #       run: npm run test:ui
 
-      - name: Test end-to-end
-        uses: GabrielBB/xvfb-action@86d97bde4a65fe9b290c0b3fb92c2c4ed0e5302d # v1.6
-        with:
-          working-directory: ${{ github.workspace }}
-          run: npm run test:e2e
+  #     - name: Test end-to-end
+  #       uses: GabrielBB/xvfb-action@86d97bde4a65fe9b290c0b3fb92c2c4ed0e5302d # v1.6
+  #       with:
+  #         working-directory: ${{ github.workspace }}
+  #         run: npm run test:e2e
 
-      - name: Lint
-        run: npm run lint
+  #     - name: Lint
+  #       run: npm run lint
 
   package:
     runs-on: ${{ matrix.os }}
-    needs: build # build packages only if regular build and tests passed
+    # needs: build # build packages only if regular build and tests passed
     strategy:
       fail-fast: false
       matrix:
@@ -143,7 +143,7 @@ jobs:
         continue-on-error: true # empty steps.tag.outputs.tag will inform the next step
 
       - name: Build binaries with electron-builder
-        uses: samuelmeuli/action-electron-builder@92327c67bc45ff7c38bf55d8aa8c4d75b7ea38e7 # v1.6.0 but safer than a tag that can be changed
+        uses: samuelmeuli/action-electron-builder@@6b1a1e42305b129c198a980c7ae4967ac69f9163 # https://github.com/samuelmeuli/action-electron-builder/pull/92
         with:
           args: --publish onTag # attach signed binaries to a release draft only when building a tag
           release: false # keep github release as draft for manual inspection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,25 +143,19 @@ jobs:
         continue-on-error: true # empty steps.tag.outputs.tag will inform the next step
 
       - name: Build binaries with electron-builder
-        uses: samuelmeuli/action-electron-builder@@6b1a1e42305b129c198a980c7ae4967ac69f9163 # https://github.com/samuelmeuli/action-electron-builder/pull/92
-        with:
-          args: --publish onTag # attach signed binaries to a release draft only when building a tag
-          release: false # keep github release as draft for manual inspection
-          max_attempts: 2
-          # GH token for attaching atrifacts to release draft on tag build
-          github_token: ${{ secrets.github_token }}
-          # Windows signing
-          windows_certs: ${{ secrets.windows_certs }}
-          windows_certs_password: ${{ secrets.windows_certs_password }}
-          # Apple signing
-          mac_certs: ${{ secrets.mac_certs }}
-          mac_certs_password: ${{ secrets.mac_certs_password }}
+        run: |
+          npm run build
+          npx --no-install electron-builder --mac --publish onTag
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ secrets.mac_certs }}
+          CSC_KEY_PASSWORD: ${{ secrets.mac_certs_password }}
           CI_BUILD_TAG: ${{steps.tag.outputs.tag}} # used by --publish onTag
           # Apple notarization
           APPLEID: ${{ secrets.apple_id }}
           APPLEIDPASS: ${{ secrets.apple_id_pass }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEBUG: electron-builder
 
       - name: Show dist/
         run: du -sh dist/ && ls -l dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Build binaries with electron-builder
         run: |
           npm run build
-          npx --no-install electron-builder --mac --publish onTag
+          npx --no-install electron-builder --publish onTag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.mac_certs }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
 
       - name: Build binaries with electron-builder
         run: |
+          npm run build
           npx --no-install electron-builder --mac --publish onTag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,19 +143,25 @@ jobs:
         continue-on-error: true # empty steps.tag.outputs.tag will inform the next step
 
       - name: Build binaries with electron-builder
-        run: |
-          npm run build
-          npx --no-install electron-builder --mac --publish onTag
+        uses: samuelmeuli/action-electron-builder@@6b1a1e42305b129c198a980c7ae4967ac69f9163 # https://github.com/samuelmeuli/action-electron-builder/pull/92
+        with:
+          args: --publish onTag # attach signed binaries to a release draft only when building a tag
+          release: false # keep github release as draft for manual inspection
+          max_attempts: 2
+          # GH token for attaching atrifacts to release draft on tag build
+          github_token: ${{ secrets.github_token }}
+          # Windows signing
+          windows_certs: ${{ secrets.windows_certs }}
+          windows_certs_password: ${{ secrets.windows_certs_password }}
+          # Apple signing
+          mac_certs: ${{ secrets.mac_certs }}
+          mac_certs_password: ${{ secrets.mac_certs_password }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ secrets.mac_certs }}
-          CSC_KEY_PASSWORD: ${{ secrets.mac_certs_password }}
           CI_BUILD_TAG: ${{steps.tag.outputs.tag}} # used by --publish onTag
           # Apple notarization
           APPLEID: ${{ secrets.apple_id }}
           APPLEIDPASS: ${{ secrets.apple_id_pass }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEBUG: electron-builder
 
       - name: Show dist/
         run: du -sh dist/ && ls -l dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         continue-on-error: true # empty steps.tag.outputs.tag will inform the next step
 
       - name: Build binaries with electron-builder
-        uses: samuelmeuli/action-electron-builder@6b1a1e42305b129c198a980c7ae4967ac69f9163 # https://github.com/samuelmeuli/action-electron-builder/pull/92
+        uses: samuelmeuli/action-electron-builder@@6b1a1e42305b129c198a980c7ae4967ac69f9163 # https://github.com/samuelmeuli/action-electron-builder/pull/92
         with:
           args: --publish onTag # attach signed binaries to a release draft only when building a tag
           release: false # keep github release as draft for manual inspection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,27 +143,18 @@ jobs:
         continue-on-error: true # empty steps.tag.outputs.tag will inform the next step
 
       - name: Build binaries with electron-builder
-        uses: samuelmeuli/action-electron-builder@6b1a1e42305b129c198a980c7ae4967ac69f9163 # https://github.com/samuelmeuli/action-electron-builder/pull/92
-        with:
-          args: --publish onTag # attach signed binaries to a release draft only when building a tag
-          release: false # keep github release as draft for manual inspection
-          max_attempts: 2
-          # GH token for attaching atrifacts to release draft on tag build
-          github_token: ${{ secrets.github_token }}
-          # Windows signing
-          windows_certs: ${{ secrets.windows_certs }}
-          windows_certs_password: ${{ secrets.windows_certs_password }}
-          # Apple signing
-          mac_certs: ${{ secrets.mac_certs }}
-          mac_certs_password: ${{ secrets.mac_certs_password }}
+        run: |
+          npx --no-install electron-builder --mac --publish onTag
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ secrets.mac_certs }}
+          CSC_KEY_PASSWORD: ${{ secrets.mac_certs_password }}
           CI_BUILD_TAG: ${{steps.tag.outputs.tag}} # used by --publish onTag
           # Apple notarization
           APPLEID: ${{ secrets.apple_id }}
           APPLEIDPASS: ${{ secrets.apple_id_pass }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEBUG: electron-builder
-          NPM_CONFIG_LOGLEVEL: silly
 
       - name: Show dist/
         run: du -sh dist/ && ls -l dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,93 +13,93 @@ env:
 
 jobs:
 
-  # build:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [macos-latest, ubuntu-latest, windows-latest]
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
-  #   steps:
-  #     - name: Fix CRLF handling on Windows
-  #       if: matrix.os == 'windows-latest'
-  #       run: git config --global core.autocrlf false
+    steps:
+      - name: Fix CRLF handling on Windows
+        if: matrix.os == 'windows-latest'
+        run: git config --global core.autocrlf false
 
-  #     - name: Check out Git repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Install Node.js
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 'lts/*'
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
 
-  #     - name: Cache bigger downloads
-  #       uses: actions/cache@v2
-  #       id: cache
-  #       with:
-  #         path: ${{ github.workspace }}/.cache
-  #         key: ${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json', 'electron-builder.yml') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json', 'electron-builder.yml') }}
-  #           ${{ runner.os }}-
+      - name: Cache bigger downloads
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: ${{ github.workspace }}/.cache
+          key: ${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json', 'electron-builder.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json', 'electron-builder.yml') }}
+            ${{ runner.os }}-
 
-  #     - name: Install dependencies
-  #       run: npm ci --prefer-offline --no-audit --progress=false --cache ${{ github.workspace }}/.cache/npm
-  #       env:
-  #           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --progress=false --cache ${{ github.workspace }}/.cache/npm
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Build
-  #       run: npm run build
+      - name: Build
+        run: npm run build
 
-  #     - name: Install Sentry CLI
-  #       if: matrix.os == 'ubuntu-latest'
-  #       run: |
-  #         curl -sL https://sentry.io/get-cli/ | bash
-  #         sentry-cli --version
+      - name: Install Sentry CLI
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          sentry-cli --version
 
-  #     - name: Configure SENTRY env vars
-  #       run:
-  #         node ./build/configure-sentry.js >> $GITHUB_ENV
-  #       env:
-  #         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      - name: Configure SENTRY env vars
+        run:
+          node ./build/configure-sentry.js >> $GITHUB_ENV
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-  #     - name: Create Sentry release
-  #       # Secrets are not passed to the runner when a workflow is triggered from a forked repository.
-  #       # See https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow
-  #       # We skip this step in such case.
-  #       #
-  #       # We must use `env` instead of `secrets`, see https://stackoverflow.com/a/70249520/69868
-  #       if: matrix.os == 'ubuntu-latest' && env.SENTRY_AUTH_TOKEN
-  #       env:
-  #         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-  #         SENTRY_ORG: protocol-labs-ip
-  #         SENTRY_PROJECT: filecoin-station
-  #       run: |
-  #         sentry-cli releases new "${{ env.SENTRY_VERSION }}"
-  #         sentry-cli releases set-commits "${{ env.SENTRY_VERSION }}" --local --ignore-missing
-  #         sentry-cli releases files "${{ env.SENTRY_VERSION }}" upload-sourcemaps ./renderer/dist/assets
-  #         sentry-cli releases deploys "${{ env.SENTRY_VERSION }}" new -e "${{ env.SENTRY_ENV }}"
+      - name: Create Sentry release
+        # Secrets are not passed to the runner when a workflow is triggered from a forked repository.
+        # See https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow
+        # We skip this step in such case.
+        #
+        # We must use `env` instead of `secrets`, see https://stackoverflow.com/a/70249520/69868
+        if: matrix.os == 'ubuntu-latest' && env.SENTRY_AUTH_TOKEN
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: protocol-labs-ip
+          SENTRY_PROJECT: filecoin-station
+        run: |
+          sentry-cli releases new "${{ env.SENTRY_VERSION }}"
+          sentry-cli releases set-commits "${{ env.SENTRY_VERSION }}" --local --ignore-missing
+          sentry-cli releases files "${{ env.SENTRY_VERSION }}" upload-sourcemaps ./renderer/dist/assets
+          sentry-cli releases deploys "${{ env.SENTRY_VERSION }}" new -e "${{ env.SENTRY_ENV }}"
 
-  #     - name: Test backend
-  #       run: npm run test:backend
+      - name: Test backend
+        run: npm run test:backend
 
-  #     - name: Test frontend
-  #       run: npm run test:ui
+      - name: Test frontend
+        run: npm run test:ui
 
-  #     - name: Test end-to-end
-  #       uses: GabrielBB/xvfb-action@86d97bde4a65fe9b290c0b3fb92c2c4ed0e5302d # v1.6
-  #       with:
-  #         working-directory: ${{ github.workspace }}
-  #         run: npm run test:e2e
+      - name: Test end-to-end
+        uses: GabrielBB/xvfb-action@86d97bde4a65fe9b290c0b3fb92c2c4ed0e5302d # v1.6
+        with:
+          working-directory: ${{ github.workspace }}
+          run: npm run test:e2e
 
-  #     - name: Lint
-  #       run: npm run lint
+      - name: Lint
+        run: npm run lint
 
   package:
     runs-on: ${{ matrix.os }}
-    # needs: build # build packages only if regular build and tests passed
+    needs: build # build packages only if regular build and tests passed
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         continue-on-error: true # empty steps.tag.outputs.tag will inform the next step
 
       - name: Build binaries with electron-builder
-        uses: samuelmeuli/action-electron-builder@@6b1a1e42305b129c198a980c7ae4967ac69f9163 # https://github.com/samuelmeuli/action-electron-builder/pull/92
+        uses: samuelmeuli/action-electron-builder@6b1a1e42305b129c198a980c7ae4967ac69f9163 # https://github.com/samuelmeuli/action-electron-builder/pull/92
         with:
           args: --publish onTag # attach signed binaries to a release draft only when building a tag
           release: false # keep github release as draft for manual inspection

--- a/build/notarize-macos.js
+++ b/build/notarize-macos.js
@@ -1,31 +1,31 @@
 'use strict'
 
-const { notarize } = require('@electron/notarize')
+// const { notarize } = require('@electron/notarize')
 
-const isSet = (/** @type {string | undefined} */ value) => value && value !== 'false'
+// const isSet = (/** @type {string | undefined} */ value) => value && value !== 'false'
 
 /**
  * electron-build hook responsible for Apple Notarization of signed DMG
  *
- * @param {import('electron-builder').AfterPackContext} context
+ * // @param {import('electron-builder').AfterPackContext} context
  */
-exports.default = async function notarizing (context) {
-  const { electronPlatformName, appOutDir } = context
-  if (electronPlatformName !== 'darwin') return
-  // skip notarization if secrets are not present in env
-  if (!process.env.APPLEID || !process.env.APPLEIDPASS) return
-  // skip notarization when signing is disabled in PRs
-  // https://github.com/electron-userland/electron-builder/commit/e1dda14
-  if (isSet(process.env.TRAVIS_PULL_REQUEST) ||
-    isSet(process.env.CI_PULL_REQUEST) ||
-    isSet(process.env.CI_PULL_REQUESTS)) return
+exports.default = async function notarizing (/* context */) {
+  // const { electronPlatformName, appOutDir } = context
+  // if (electronPlatformName !== 'darwin') return
+  // // skip notarization if secrets are not present in env
+  // if (!process.env.APPLEID || !process.env.APPLEIDPASS) return
+  // // skip notarization when signing is disabled in PRs
+  // // https://github.com/electron-userland/electron-builder/commit/e1dda14
+  // if (isSet(process.env.TRAVIS_PULL_REQUEST) ||
+  //   isSet(process.env.CI_PULL_REQUEST) ||
+  //   isSet(process.env.CI_PULL_REQUESTS)) return
 
-  const appName = context.packager.appInfo.productFilename
+  // const appName = context.packager.appInfo.productFilename
 
-  return notarize({
-    appBundleId: 'io.filecoin.station',
-    appPath: `${appOutDir}/${appName}.app`,
-    appleId: process.env.APPLEID,
-    appleIdPassword: process.env.APPLEIDPASS
-  })
+  // return notarize({
+  //   appBundleId: 'io.filecoin.station',
+  //   appPath: `${appOutDir}/${appName}.app`,
+  //   appleId: process.env.APPLEID,
+  //   appleIdPassword: process.env.APPLEIDPASS
+  // })
 }

--- a/build/notarize-macos.js
+++ b/build/notarize-macos.js
@@ -1,31 +1,35 @@
 'use strict'
 
-// const { notarize } = require('@electron/notarize')
+const { notarize } = require('@electron/notarize')
 
-// const isSet = (/** @type {string | undefined} */ value) => value && value !== 'false'
+const isSet = (/** @type {string | undefined} */ value) => value && value !== 'false'
 
 /**
  * electron-build hook responsible for Apple Notarization of signed DMG
  *
- * // @param {import('electron-builder').AfterPackContext} context
+ * @param {import('electron-builder').AfterPackContext} context
  */
-exports.default = async function notarizing (/* context */) {
-  // const { electronPlatformName, appOutDir } = context
-  // if (electronPlatformName !== 'darwin') return
-  // // skip notarization if secrets are not present in env
-  // if (!process.env.APPLEID || !process.env.APPLEIDPASS) return
-  // // skip notarization when signing is disabled in PRs
-  // // https://github.com/electron-userland/electron-builder/commit/e1dda14
-  // if (isSet(process.env.TRAVIS_PULL_REQUEST) ||
-  //   isSet(process.env.CI_PULL_REQUEST) ||
-  //   isSet(process.env.CI_PULL_REQUESTS)) return
+exports.default = async function notarizing (context) {
+  const { electronPlatformName, appOutDir } = context
+  if (electronPlatformName !== 'darwin') return
+  // skip notarization if secrets are not present in env
+  if (!process.env.APPLEID || !process.env.APPLEIDPASS) return
+  // skip notarization when signing is disabled in PRs
+  // https://github.com/electron-userland/electron-builder/blob/ece7f889f93921894cbbcb02b924dc90d793be7c/packages/builder-util/src/util.ts#L322-L336
+  if (
+    isSet(process.env.TRAVIS_PULL_REQUEST) ||
+    isSet(process.env.CIRCLE_PULL_REQUEST) ||
+    isSet(process.env.BITRISE_PULL_REQUEST) ||
+    isSet(process.env.APPVEYOR_PULL_REQUEST_NUMBER) ||
+    isSet(process.env.GITHUB_BASE_REF)
+  ) return
 
-  // const appName = context.packager.appInfo.productFilename
+  const appName = context.packager.appInfo.productFilename
 
-  // return notarize({
-  //   appBundleId: 'io.filecoin.station',
-  //   appPath: `${appOutDir}/${appName}.app`,
-  //   appleId: process.env.APPLEID,
-  //   appleIdPassword: process.env.APPLEIDPASS
-  // })
+  return notarize({
+    appBundleId: 'io.filecoin.station',
+    appPath: `${appOutDir}/${appName}.app`,
+    appleId: process.env.APPLEID,
+    appleIdPassword: process.env.APPLEIDPASS
+  })
 }

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,14 +13,14 @@ files:
     - package.json
 
 extraResources:
-  - from: 'build/saturn/l2node-${platform}-${arch}'
+  - from: './build/saturn/l2node-${platform}-${arch}'
     to: 'saturn-l2-node'
     filter: ['*']
 
-asarUnpack: 'main/**/scripts/**/*'
+asarUnpack: './main/**/scripts/**/*'
 
-beforePack: 'build/before-pack.js'
-afterSign: 'build/notarize-macos.js'
+beforePack: './build/before-pack.js'
+afterSign: './build/notarize-macos.js'
 artifactName: '${productName}.${ext}'
 
 mac:
@@ -28,8 +28,8 @@ mac:
   darkModeSupport: true
   hardenedRuntime: true
   gatekeeperAssess: false
-  entitlements: 'build/entitlements.mac.plist'
-  entitlementsInherit: 'build/entitlements.mac.plist'
+  entitlements: './build/entitlements.mac.plist'
+  entitlementsInherit: './build/entitlements.mac.plist'
   target:
     - target: dmg
       arch: ['x64']

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -6,18 +6,18 @@ extraMetadata:
 
 files:
   - filter:
-    - ./main/**/*
-    - ./assets/**/*
-    - ./renderer/dist/**/*
-    - ./node_modules/**/*
-    - ./package.json
+    - main/**/*
+    - assets/**/*
+    - renderer/dist/**/*
+    - node_modules/**/*
+    - package.json
 
 extraResources:
-  - from: './build/saturn/l2node-${platform}-${arch}'
+  - from: 'build/saturn/l2node-${platform}-${arch}'
     to: 'saturn-l2-node'
     filter: ['*']
 
-asarUnpack: './main/**/scripts/**/*'
+asarUnpack: 'main/**/scripts/**/*'
 
 beforePack: './build/before-pack.js'
 afterSign: './build/notarize-macos.js'
@@ -28,8 +28,8 @@ mac:
   darkModeSupport: true
   hardenedRuntime: true
   gatekeeperAssess: false
-  entitlements: './build/entitlements.mac.plist'
-  entitlementsInherit: './build/entitlements.mac.plist'
+  entitlements: 'build/entitlements.mac.plist'
+  entitlementsInherit: 'build/entitlements.mac.plist'
   target:
     - target: dmg
       arch: ['x64']

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -6,11 +6,11 @@ extraMetadata:
 
 files:
   - filter:
-    - main/**/*
-    - assets/**/*
-    - renderer/dist/**/*
-    - node_modules/**/*
-    - package.json
+    - ./main/**/*
+    - ./assets/**/*
+    - ./renderer/dist/**/*
+    - ./node_modules/**/*
+    - ./package.json
 
 extraResources:
   - from: './build/saturn/l2node-${platform}-${arch}'


### PR DESCRIPTION
- `action-electron-builder` is unmaintained &mdash; I'm a maintainer but I don't have time to pick it up again
- What it's providing isn't complex and can easily be inlined
- We need to switch from `npx` to `npm exec` for https://github.com/electron-userland/electron-builder/issues/6411, this changes prepares us for this
- The hooks weren't running - `electron-builder` is silently failing here. I've turned on `DEBUG` in the meantime, until this stabilizes
- I had to fix the `isPullRequest()` logic copied from `electron-builder`, which wasn't reading Github Actions env vars yet
- CI is passing, see the second to last commit. I had to disable the `build` step for it to pass, since there currently is a Saturn testnet issue: No nodes are available