### PR TITLE
fix build .zip on mac

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -33,6 +33,8 @@ mac:
   target:
     - target: dmg
       arch: ['x64']
+    - target: zip
+      arch: ['x64']
 
 
 dmg:


### PR DESCRIPTION
> target String | [TargetConfiguration](https://www.electron.build/cli#targetconfiguration) - The target package type: list of default, dmg, mas, mas-dev, pkg, 7z, zip, tar.xz, tar.lz, tar.gz, tar.bz2, dir. Defaults to default (dmg and zip for Squirrel.Mac). Note: Squirrel.Mac auto update mechanism requires both dmg and zip to be enabled, even when only dmg is used. Disabling zip will break auto update in dmg packages.