### PR TITLE
Update telemetry fields

### DIFF
--- a/main/station-config.js
+++ b/main/station-config.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Store = require('electron-store')
-const { randomUUID } = require('crypto')
 
 const log = require('electron-log').scope('config')
 
@@ -50,9 +49,6 @@ let TrayOperationExplained =
 let DestinationFilAddress =
   /** @type {string | undefined} */
   (configStore.get(ConfigKeys.DestinationFilAddress))
-const StationID =
-  /** @type {string} */
-  (configStore.get(ConfigKeys.StationID, randomUUID()))
 
 /**
  * @returns {boolean}
@@ -85,13 +81,6 @@ function setTrayOperationExplained () {
 }
 
 /**
- * @returns {string}
- */
-function getStationID () {
-  return StationID
-}
-
-/**
  * @returns {string | undefined}
  */
 function getDestinationWalletAddress () {
@@ -111,7 +100,6 @@ module.exports = {
   setOnboardingCompleted,
   getTrayOperationExplained,
   setTrayOperationExplained,
-  getStationID,
   getDestinationWalletAddress,
   setDestinationWalletAddress
 }

--- a/main/telemetry.js
+++ b/main/telemetry.js
@@ -2,6 +2,7 @@
 
 const { InfluxDB } = require('@influxdata/influxdb-client')
 const { createHash } = require('node:crypto')
+const { getDestinationWalletAddress } = require('./station-config')
 const wallet = require('./wallet')
 const Sentry = require('@sentry/node')
 
@@ -37,9 +38,19 @@ setInterval(() => {
  * @param {Point} point
  */
 const writePoint = point => {
-  const hash = createHash('sha256').update(wallet.getAddress()).digest('hex')
-  point.stringField('wallet', hash)
-  // point.stringField('station', getStationID())
+  point.stringField(
+    'wallet',
+    createHash('sha256').update(wallet.getAddress()).digest('hex')
+  )
+
+  const destinationWalletAddress = getDestinationWalletAddress()
+  if (destinationWalletAddress) {
+    point.stringField(
+      'destination_wallet',
+      createHash('sha256').update(destinationWalletAddress).digest('hex')
+    )
+  }
+
   writeClient.writePoint(point)
 }
 

--- a/main/telemetry.js
+++ b/main/telemetry.js
@@ -2,7 +2,6 @@
 
 const { InfluxDB } = require('@influxdata/influxdb-client')
 const { createHash } = require('node:crypto')
-const { getStationID } = require('./station-config')
 const wallet = require('./wallet')
 const Sentry = require('@sentry/node')
 
@@ -40,7 +39,7 @@ setInterval(() => {
 const writePoint = point => {
   const hash = createHash('sha256').update(wallet.getAddress()).digest('hex')
   point.stringField('wallet', hash)
-  point.stringField('station', getStationID())
+  // point.stringField('station', getStationID())
   writeClient.writePoint(point)
 }
 


### PR DESCRIPTION
`StationID` is redundant now, since every Station already has a wallet address, which is unique. Instead, add the destination wallet address as a new field, which can give us an indication of how many users we potentially have, and how many people run Station without having a destination wallet configured.