### PR TITLE
Display tray on/off state

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -174,7 +174,7 @@ async function run () {
 
   try {
     // Interface
-    await setupTray(ctx)
+    setupTray(ctx)
     setupDialogs(ctx)
     if (process.platform === 'darwin') {
       await setupAppMenu(ctx)

--- a/main/saturn-node.js
+++ b/main/saturn-node.js
@@ -19,6 +19,7 @@ const saturnBinaryPath = getSaturnBinaryPath()
 let childProcess = null
 
 let ready = false
+let online = false
 /** @type {string | null} */
 let moduleExitReason = null
 
@@ -226,6 +227,10 @@ function isReady () {
   return ready
 }
 
+function isOnline () {
+  return online
+}
+
 function getWebUrl () {
   return webUrl
 }
@@ -269,10 +274,26 @@ function handleActivityLogs (ctx, text) {
       const m = line.match(/^(INFO|ERROR): (.*)$/)
       if (!m) return
 
+      const type = /** @type {any} */(m[1].toLowerCase())
+      const message = m[2]
+
+      if (type === 'info' && message.includes('Saturn Node is online')) {
+        online = true
+      } else if (
+        type === 'error' ||
+        (
+          message === 'Saturn Node started.' ||
+          message.includes('was able to connect') ||
+          message.includes('will try to connect')
+        )
+      ) {
+        online = false
+      }
+
       ctx.recordActivity({
         source: 'Saturn',
-        type: /** @type {any} */(m[1].toLowerCase()),
-        message: m[2]
+        type,
+        message
       })
     })
 }
@@ -307,6 +328,7 @@ module.exports = {
   stop,
   isRunning,
   isReady,
+  isOnline,
   getLog,
   getWebUrl
 }

--- a/main/tray.js
+++ b/main/tray.js
@@ -95,9 +95,8 @@ function setupIpcEventListeners (contextMenu, ctx) {
   ipcMain.on(ipcMainEvents.ACTIVITY_LOGGED, () => {
     assert(tray)
 
-    const entries = ctx.getAllActivities()
     let connected = false
-    for (const entry of entries.reverse()) {
+    for (const entry of ctx.getAllActivities().reverse()) {
       if (
         entry.source === 'Saturn' &&
         entry.type === 'info' &&

--- a/main/tray.js
+++ b/main/tray.js
@@ -25,7 +25,6 @@ module.exports = function (/** @type {Context} */ ctx) {
   const image = nativeImage.createFromPath(icon('off'))
   image.setTemplateImage(true)
   tray = new Tray(image)
-
   const contextMenu = Menu.buildFromTemplate([
     {
       label: `Filecoin Station v${STATION_VERSION}`,

--- a/main/tray.js
+++ b/main/tray.js
@@ -4,6 +4,9 @@ const { IS_MAC, STATION_VERSION } = require('./consts')
 const { Menu, Tray, app, ipcMain, nativeImage } = require('electron')
 const { ipcMainEvents } = require('./ipc')
 const path = require('path')
+const timers = require('node:timers/promises')
+
+/** @typedef {import('./typings').Context} Context */
 
 // Be warned, this one is pretty ridiculous:
 // Tray must be global or it will break due to.. GC.
@@ -16,10 +19,51 @@ function icon (/** @type {'on' | 'off'} */ state) {
   return path.join(dir, `${state}.png`)
 }
 
-module.exports = function (/** @type {import('./typings').Context} */ ctx) {
-  const image = nativeImage.createFromPath(icon('on'))
+module.exports = function (/** @type {Context} */ ctx) {
+  const image = nativeImage.createFromPath(
+    icon(Math.random() > 0.5 ? 'on' : 'off')
+  )
   image.setTemplateImage(true)
   tray = new Tray(image)
+
+  ;(async () => {
+    while (true) {
+      await timers.setTimeout(1000)
+
+      // Check if connected to Saturn network
+      const entries = ctx.getAllActivities()
+      let connected = false
+      for (const entry of entries.reverse()) {
+        if (
+          entry.source === 'Saturn' &&
+          entry.type === 'info' &&
+          entry.message.includes('Saturn Node is online')
+        ) {
+          connected = true
+          break
+        } else if (
+          entry.source === 'Saturn' &&
+          (
+            entry.type === 'error' ||
+            (
+              entry.message === 'Saturn Node started.' ||
+              entry.message.includes('was able to connect') ||
+              entry.message.includes('will try to connect')
+            )
+          )
+        ) {
+          connected = false
+          break
+        }
+      }
+
+      const state = connected ? 'on' : 'off'
+      const image = nativeImage.createFromPath(icon(state))
+      image.setTemplateImage(true)
+      tray.setImage(image)
+    }
+  })()
+
   const contextMenu = Menu.buildFromTemplate([
     {
       label: `Filecoin Station v${STATION_VERSION}`,

--- a/main/tray.js
+++ b/main/tray.js
@@ -16,16 +16,21 @@ const saturn = require('./saturn-node')
 /** @type {Tray | null} */
 let tray = null
 
+const icons = {
+  on: icon('on'),
+  off: icon('off')
+}
+
 function icon (/** @type {'on' | 'off'} */ state) {
   const dir = path.resolve(path.join(__dirname, '../assets/tray'))
-  if (IS_MAC) return path.join(dir, `${state}-macos.png`)
-  return path.join(dir, `${state}.png`)
+  const file = IS_MAC ? `${state}-macos.png` : `${state}.png`
+  const image = nativeImage.createFromPath(path.join(dir, file))
+  image.setTemplateImage(true)
+  return image
 }
 
 module.exports = function (/** @type {Context} */ ctx) {
-  const image = nativeImage.createFromPath(icon('off'))
-  image.setTemplateImage(true)
-  tray = new Tray(image)
+  tray = new Tray(icons.off)
   const contextMenu = Menu.buildFromTemplate([
     {
       label: `Filecoin Station v${STATION_VERSION}`,
@@ -95,9 +100,7 @@ function setupIpcEventListeners (contextMenu) {
     assert(tray)
 
     const state = saturn.isOnline() ? 'on' : 'off'
-    const image = nativeImage.createFromPath(icon(state))
-    image.setTemplateImage(true)
-    tray.setImage(image)
+    tray.setImage(icons[state])
   })
 
   /**


### PR DESCRIPTION
This is a follow-up on https://github.com/filecoin-station/filecoin-station/pull/177, where we added the tray assets, but the logic wasn't yet wired up.

This makes it so the Station tray icon changes depending on whether you're connected to the Saturn network.